### PR TITLE
langchain-core 0.1.23 :snowflake:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-    - https://staging.continuum.io/prefect/fs/jsonpatch-feedstock/pr1/58ac14a
-    - https://staging.continuum.io/prefect/fs/packaging-feedstock/pr10/866d63c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+    - https://staging.continuum.io/prefect/fs/jsonpatch-feedstock/pr1/58ac14a
+    - https://staging.continuum.io/prefect/fs/packaging-feedstock/pr10/866d63c

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-core" %}
-{% set version = "0.1.32" %}
+{% set version = "0.1.23" %}
 
 package:
   name: {{ name|lower }}
@@ -7,22 +7,21 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/langchain_core-{{ version }}.tar.gz
-  sha256: d62683becbf20f51f12875791a042320f45eaa0c87a267d30bc03bc1a07f5ec2
+  sha256: 34359cc8b6f8c3d45098c54a6a9b35c9f538ef58329cd943a2249d6d7b4e5806
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.8,<4.0
+    - python
     - poetry-core >=1.0.0
     - pip
   run:
-    - python >=3.8.1,<4.0
+    - python
     - pydantic >=1,<3
-    - langsmith >=0.1.0,<0.2.0
+    - langsmith >=0.0.87,<0.0.88
     - tenacity >=8.1.0,<9.0.0
     - jsonpatch >=1.33.0,<2.0.0
     - anyio >=3,<5
@@ -35,19 +34,20 @@ requirements:
 test:
   imports:
     - langchain_core
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/langchain-ai/langchain
-  doc_url: https://api.python.langchain.com/en/stable/core_api_reference.html
-  dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/core
   summary: Core APIs for LangChain, the LLM framework for buildilng applications through composability
   description: LangChain Core contains the core abstractions powering LangChain, including LangChain Expression Language.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  dev_url: https://github.com/langchain-ai/langchain/tree/master/libs/core
+  doc_url: https://api.python.langchain.com/en/stable/core_api_reference.html
 
 extra:
   recipe-maintainers:
@@ -57,3 +57,5 @@ extra:
     - efriis
     - agola11
     - pavelzw
+  skip-lints:
+    - missing_wheel


### PR DESCRIPTION
langchain-core 0.1.23 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4036]
- dev_url (pypi): (this is the main langchain, the langchain-core seems to not have a repo or it is a monorepo, but I did not find any release tag for it, see inspector) https://github.com/langchain-ai/langchain
- inspector: https://inspector.pypi.io/project/langchain-core/0.1.23/
- conda-forge: https://github.com/conda-forge/langchain-core-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/langchain-core

### Explanation of changes:

- bump
- .gitignore
- upload channel to SF
- new feedstock


[PKG-4036]: https://anaconda.atlassian.net/browse/PKG-4036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ