### PR TITLE
[PKG-4415] 0.1.52

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,12 +24,10 @@ requirements:
   run:
     - python
     - pydantic >=1,<3
-    - langsmith >=0.0.87,<0.0.88
+    - langsmith >=0.1.0,<0.2.0
     - tenacity >=8.1.0,<9.0.0
     - jsonpatch >=1.33.0,<2.0.0
-    - anyio >=3,<5
     - pyyaml >=5.3
-    - requests >=2.0.0,<3.0.0
     - packaging >=23.2.0,<24.0.0
   run_constrained:
     - jinja2 >=3.0.0,<4.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install ./libs/core --no-deps --no-build-isolation -vv
+  skip: true  # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,25 @@ requirements:
     - jinja2 >=3.0.0,<4.0.0
 
 test:
+  source_files:
+    - libs/core
   imports:
     - langchain_core
   requires:
     - pip
+    - pytest >=7.3.0,<8
+    - pytest-mock >=3.10.0,<4
+    - numpy >=1.24.0,<2
+    - responses >=0.25.0,<0.26.0
+    # Versions expected by upstream not on defaults yet.
+    - pytest-asyncio #>=0.21.1,<0.22
+    - freezegun #>=1.2.2,<2
+    # Deps below not on defaults, required for ignored tests below
+    # syrupy, grandalf, pytest-profiling, pytest-watcher
   commands:
     - pip check
+    - cd libs/core
+    - pytest tests/unit_tests --strict-markers --strict-config  --ignore=tests/unit_tests/runnables/test_fallbacks.py --ignore=tests/unit_tests/runnables/test_graph.py --ignore=tests/unit_tests/runnables/test_runnable.py
 
 about:
   home: https://github.com/langchain-ai/langchain

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "langchain-core" %}
-{% set version = "0.1.23" %}
+{% set version = "0.1.52" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/langchain_core-{{ version }}.tar.gz
-  sha256: 34359cc8b6f8c3d45098c54a6a9b35c9f538ef58329cd943a2249d6d7b4e5806
+  url: https://github.com/langchain-ai/langchain/archive/refs/tags/{{ name }}=={{ version }}.tar.gz
+  sha256: 6ee62ad7c8ce418e443f50dcf32ae61dd170a11a219a994173d872b0022872c2
+  patches:
+    - remove-pytest-options.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   requires:
     - pip
     - pytest >=7.3.0,<8
-    - pytest-mock >=3.10.0,<4
+    - pytest-mock >=3.10.0,<4  # [not (osx and x86 and py>=312)]
     - numpy >=1.24.0,<2
     - responses >=0.25.0,<0.26.0
     # Versions expected by upstream not on defaults yet.
@@ -54,7 +54,12 @@ test:
   commands:
     - pip check
     - cd libs/core
-    - pytest tests/unit_tests --strict-markers --strict-config  --ignore=tests/unit_tests/runnables/test_fallbacks.py --ignore=tests/unit_tests/runnables/test_graph.py --ignore=tests/unit_tests/runnables/test_runnable.py
+    {% set pytest_args = "--strict-markers --strict-config" %}
+    {% set pytest_args = pytest_args + " --ignore=tests/unit_tests/runnables/test_fallbacks.py" %}
+    {% set pytest_args = pytest_args + " --ignore=tests/unit_tests/runnables/test_graph.py" %}
+    {% set pytest_args = pytest_args + " --ignore=tests/unit_tests/runnables/test_runnable.py" %}
+    {% set pytest_args = pytest_args + ' -k "not test_async_cleanup_with_different_batchsize"' %}  # [win]
+    - pytest tests/unit_tests {{ pytest_args }} # [not (osx and x86 and py>=312)]
 
 about:
   home: https://github.com/langchain-ai/langchain

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,9 @@ build:
   skip: true  # [py<38]
 
 requirements:
+  build:
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - python
     - poetry-core >=1.0.0

--- a/recipe/remove-pytest-options.patch
+++ b/recipe/remove-pytest-options.patch
@@ -1,0 +1,12 @@
+diff --git a/libs/core/pyproject.toml b/libs/core/pyproject.toml
+index 573bf02..19464c7 100644
+--- a/libs/core/pyproject.toml
++++ b/libs/core/pyproject.toml
+@@ -97,7 +97,6 @@ build-backend = "poetry.core.masonry.api"
+ #
+ # https://github.com/tophat/syrupy
+ # --snapshot-warn-unused    Prints a warning on unused snapshots rather than fail the test suite.
+-addopts = "--snapshot-warn-unused --strict-markers --strict-config --durations=5"
+ # Registering custom markers.
+ # https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers
+ markers = [


### PR DESCRIPTION
langchain-core 0.1.52 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4415]
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/langchain-core%3D%3D0.1.52/libs/core)
- [Upstream changelog/diff](https://github.com/langchain-ai/langchain/compare/langchain-core%3D%3D0.1.51...langchain-core%3D%3D0.1.52)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/langsmith-feedstock/pull/3

### Explanation of changes:

- Added upstream tests
- Swapped to Github source to include testing.
- Added a patch to bypass `pytest` options in `pyproject.toml`, as they require `syrupy` which is missing from defaults.


[PKG-4415]: https://anaconda.atlassian.net/browse/PKG-4415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ