### PR TITLE
Update version to 1.2.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "langchain-core" %}
-{% set version = "1.2.6" %}
+{% set version = "1.2.7" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: b4e7841dd7f8690375aa07c54739178dc2c635147d475e0c2955bf82a1afa498
+  sha256: e1460639f96c352b4a41c375f25aeb8d16ffc1769499fb1c20503aad59305ced
   patches:
     - patches/0001-patch_conftest.patch
 


### PR DESCRIPTION
langchain-core 1.2.7

**Destination channel:** {Snowflake | defaults}

### Links

- [PKG-11998](https://anaconda.atlassian.net/browse/PKG-11998) 
- [Upstream repository](https://github.com/langchain-ai/langchain)

### Explanation of changes:

- new version number


[PKG-11998]: https://anaconda.atlassian.net/browse/PKG-11998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ